### PR TITLE
Solr connection factory

### DIFF
--- a/src/main/java/uk/ac/ox/it/skossuggester/cli/SkosFileImporter.java
+++ b/src/main/java/uk/ac/ox/it/skossuggester/cli/SkosFileImporter.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.common.SolrInputDocument;
 import uk.ac.ox.it.skossuggester.configuration.AppConfiguration;
 
@@ -55,7 +55,7 @@ public class SkosFileImporter extends ConfiguredCommand<AppConfiguration> {
     
     @Override
     protected void run(Bootstrap<AppConfiguration> bootstrap, Namespace namespace, AppConfiguration configuration) throws Exception {
-        HttpSolrServer solr = new HttpSolrServer(configuration.getSolrLocation());
+        SolrServer solr = configuration.getSolrServer(null);
         Collection<SolrInputDocument> documents = this.getDocsFromFile((File)namespace.get("skosFile"),
                 namespace.getString("fileFormat"));
         solr.add(documents);

--- a/src/main/java/uk/ac/ox/it/skossuggester/cli/TdbImporter.java
+++ b/src/main/java/uk/ac/ox/it/skossuggester/cli/TdbImporter.java
@@ -42,7 +42,7 @@ public class TdbImporter extends ConfiguredCommand<AppConfiguration> {
     
     @Override
     protected void run(Bootstrap<AppConfiguration> btstrp, Namespace namespace, AppConfiguration configuration) throws Exception {
-        ConcurrentUpdateSolrServer solr = new ConcurrentUpdateSolrServer(configuration.getSolrLocation(), 100, 3);
+        ConcurrentUpdateSolrServer solr = new ConcurrentUpdateSolrServer(configuration.getHttpSolr().getSolrLocation(), 100, 3);
         File tdbDirectory = (File)namespace.get("tdbDirectory");
         Dataset dataset = TDBFactory.createDataset(tdbDirectory.getAbsolutePath());
         Model tdb = dataset.getDefaultModel();

--- a/src/main/java/uk/ac/ox/it/skossuggester/configuration/AppConfiguration.java
+++ b/src/main/java/uk/ac/ox/it/skossuggester/configuration/AppConfiguration.java
@@ -1,17 +1,54 @@
 package uk.ac.ox.it.skossuggester.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import org.apache.solr.client.solrj.SolrServer;
 
 
 public class AppConfiguration extends Configuration {
-    
-    private String solrLocation = new String();
 
-    public String getSolrLocation() {
-        return solrLocation;
+    private SolrCloudFactory solrCloud = new SolrCloudFactory();
+    
+    private HttpSolrFactory httpSolr = new HttpSolrFactory();
+
+    @JsonProperty("solrCloud")
+    public SolrCloudFactory getSolrCloud() {
+        return solrCloud;
     }
 
-    public void setSolrLocation(String solrLocation) {
-        this.solrLocation = solrLocation;
+    @JsonProperty("solrCloud")
+    public void setSolrCloud(SolrCloudFactory solrCloud) {
+        this.solrCloud = solrCloud;
+    }
+
+    @JsonProperty("solrHttp")
+    public HttpSolrFactory getHttpSolr() {
+        return httpSolr;
+    }
+
+    @JsonProperty("solrHttp")
+    public void setHttpSolr(HttpSolrFactory httpSolr) {
+        this.httpSolr = httpSolr;
+    }
+    
+    /**
+     * Get a SolrServer depending on the configuration
+     * @param environment Dropwizard Environment
+     * @return SolrServer
+     * @throws Exception 
+     */
+    @JsonIgnore
+    public SolrServer getSolrServer(Environment environment) throws Exception {
+        if (this.httpSolr.isValid() && this.solrCloud.isValid()) {
+            throw new Exception("You need to specify either solrCloud or solrHttp, not both.");
+        } else if (this.httpSolr.isValid()) {
+            return this.httpSolr.build(environment);
+        } else if (this.solrCloud.isValid()) {
+            return this.solrCloud.build(environment);
+        } else {
+            throw new Exception("You need to specify either solrCloud or solrHttp");
+        }
     }
 }

--- a/src/main/java/uk/ac/ox/it/skossuggester/configuration/HttpSolrFactory.java
+++ b/src/main/java/uk/ac/ox/it/skossuggester/configuration/HttpSolrFactory.java
@@ -1,0 +1,52 @@
+package uk.ac.ox.it.skossuggester.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.setup.Environment;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
+
+/**
+ *
+ * @author martinfilliau
+ */
+public class HttpSolrFactory {
+    
+    private String solrLocation;
+
+    @JsonProperty("url")
+    public String getSolrLocation() {
+        return solrLocation;
+    }
+
+    @JsonProperty("url")
+    public void setSolrLocation(String solrLocation) {
+        this.solrLocation = solrLocation;
+    }
+    
+    public boolean isValid() {
+        return this.solrLocation != null;
+    }
+    
+    public HttpSolrServer build(Environment environment) throws Exception {
+        if (this.isValid()) {
+            final HttpSolrServer solr = new HttpSolrServer(this.solrLocation);
+            solr.setConnectionTimeout(1000);    // 1 second
+            solr.setSoTimeout(1000);    // 1 second
+            if (environment != null) {
+                environment.lifecycle().manage(new Managed() {
+                    @Override
+                    public void start() throws Exception {
+                    }
+
+                    @Override
+                    public void stop() throws Exception {
+                        solr.shutdown();
+                    }
+                });                
+            }
+            return solr;
+        } else {
+            throw new Exception("Missing parameters to instantiate HttpSolrServer");
+        }
+    }
+}

--- a/src/main/java/uk/ac/ox/it/skossuggester/configuration/SolrCloudFactory.java
+++ b/src/main/java/uk/ac/ox/it/skossuggester/configuration/SolrCloudFactory.java
@@ -1,0 +1,68 @@
+package uk.ac.ox.it.skossuggester.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.setup.Environment;
+import org.apache.solr.client.solrj.impl.CloudSolrServer;
+
+/**
+ *
+ * @author martinfilliau
+ */
+public class SolrCloudFactory {
+
+    private String zookeperLocation;
+    
+    private String collectionName;
+
+    @JsonProperty
+    public String getZookeperLocation() {
+        return zookeperLocation;
+    }
+
+    @JsonProperty
+    public void setZookeperLocation(String zookeperLocation) {
+        this.zookeperLocation = zookeperLocation;
+    }
+
+    @JsonProperty
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    @JsonProperty
+    public void setCollectionName(String collectionName) {
+        this.collectionName = collectionName;
+    }
+    
+    /**
+     * Check if the configuration is valid
+     * @return true if configuration is ok else false
+     */
+    public boolean isValid() {
+        return zookeperLocation != null && collectionName != null;
+    }
+    
+    public CloudSolrServer build(Environment environment) throws Exception {
+        if (this.isValid()) {
+            final CloudSolrServer solrCloud = new CloudSolrServer(this.zookeperLocation);
+            solrCloud.setDefaultCollection(this.collectionName);
+            if (environment != null) {
+                environment.lifecycle().manage(new Managed() {
+                    @Override
+                    public void start() throws Exception {
+                        solrCloud.connect();
+                    }
+
+                    @Override
+                    public void stop() throws Exception {
+                        solrCloud.shutdown();
+                    }
+                });                
+            }
+            return solrCloud;
+        } else {
+            throw new Exception("Missing parameters to initiate SolrCloud client");
+        }
+    }
+}

--- a/src/test/java/uk/ac/ox/it/skossuggester/resources/SearchTest.java
+++ b/src/test/java/uk/ac/ox/it/skossuggester/resources/SearchTest.java
@@ -1,10 +1,12 @@
 package uk.ac.ox.it.skossuggester.resources;
 
 import com.google.common.base.Optional;
+import com.google.common.io.Resources;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import java.io.File;
 import static org.hamcrest.Matchers.is;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -33,7 +35,7 @@ public class SearchTest {
     
     @ClassRule
     public static final DropwizardAppRule<AppConfiguration> RULE = 
-            new DropwizardAppRule<>(SkosSuggesterApplication.class, null);
+            new DropwizardAppRule<>(SkosSuggesterApplication.class, new File(Resources.getResource("configuration.yml.example").toURI()).getAbsolutePath());
 
     
     private SkosConcepts concepts;


### PR DESCRIPTION
Use a `SolrServer` instead of the implementation so that we can use a `SolrCloudServer` instead of a `HttpSolrServer`.

Remaining to be done:
- [ ] handle the case of the `ConcurrentUpdateSolrServer` 
- [ ] fix tests now failing because the configuration is required
- [ ] update documentation and settings
